### PR TITLE
Fix lint warnings by removing lock-copy patterns and redundant type a…

### DIFF
--- a/client/client_eth.go
+++ b/client/client_eth.go
@@ -214,7 +214,7 @@ func (c *RpcEthClient) SendTransactionByArgs(args types.TransactionArgs) (txHash
 	return
 }
 
-func (c *RpcEthClient) SendTransaction(from common.Address, tx types.Transaction) (txHash common.Hash, err error) {
+func (c *RpcEthClient) SendTransaction(from common.Address, tx *types.Transaction) (txHash common.Hash, err error) {
 	txArgs := types.ConvertTransactionToArgs(from, tx)
 	return c.SendTransactionByArgs(*txArgs)
 }

--- a/client_abigen.go
+++ b/client_abigen.go
@@ -123,7 +123,7 @@ func (c *ClientForContract) SendTransaction(ctx context.Context, tx *types.Trans
 		}
 
 		account := sm.List()[0].Address()
-		_, err = c.raw.Eth.SendTransaction(account, *tx)
+		_, err = c.raw.Eth.SendTransaction(account, tx)
 		return err
 	}
 

--- a/client_tx_test.go
+++ b/client_tx_test.go
@@ -42,7 +42,7 @@ func TestSendTransactionUseEthClient(t *testing.T) {
 
 	// legacy tx
 	tx := ethrpctypes.NewTransaction(nonce.Uint64(), to, big.NewInt(1), 1000000, big.NewInt(20000000000), nil)
-	txhash, err := c.SendTransaction(from, *tx)
+	txhash, err := c.SendTransaction(from, tx)
 	assert.NoError(t, err)
 	fmt.Printf("txhash: %s\n", txhash)
 
@@ -51,7 +51,7 @@ func TestSendTransactionUseEthClient(t *testing.T) {
 		To:    &to,
 		Value: big.NewInt(1),
 	}
-	txhash, err = c.SendTransaction(from, *ethrpctypes.NewTx(dtx))
+	txhash, err = c.SendTransaction(from, ethrpctypes.NewTx(dtx))
 	assert.NoError(t, err)
 	fmt.Printf("txhash: %s\n", txhash)
 }

--- a/providers/provider_sign.go
+++ b/providers/provider_sign.go
@@ -17,7 +17,7 @@ import (
 )
 
 type SignableMiddleware struct {
-	manager  signers.SignerManager
+	manager  *signers.SignerManager
 	provider pinterfaces.Provider
 }
 
@@ -37,7 +37,7 @@ func NewSignableProvider(p pinterfaces.Provider, signManager *signers.SignerMana
 	mp := pproviders.NewMiddlewarableProvider(p)
 
 	mid := &SignableMiddleware{
-		manager:  *signManager,
+		manager:  signManager,
 		provider: p,
 	}
 	mp.HookCallContext(mid.CallContextMiddleware)
@@ -87,7 +87,7 @@ func (s *SignableMiddleware) signTxAndEncode(tx interface{}) (hexutil.Bytes, err
 
 	var txArgs types.TransactionArgs
 
-	switch tx.(type) {
+	switch tx := tx.(type) {
 	case map[string]interface{}:
 		j, err := json.Marshal(tx)
 		if err != nil {
@@ -98,9 +98,9 @@ func (s *SignableMiddleware) signTxAndEncode(tx interface{}) (hexutil.Bytes, err
 			return nil, err
 		}
 	case types.TransactionArgs:
-		txArgs = tx.(types.TransactionArgs)
+		txArgs = tx
 	case *types.TransactionArgs:
-		txArgs = *tx.(*types.TransactionArgs)
+		txArgs = *tx
 	}
 
 	var signer interfaces.Signer

--- a/types/trace.go
+++ b/types/trace.go
@@ -235,7 +235,7 @@ func getActionAndResult(data []byte) (interface{}, interface{}, error) {
 	if action, err = parseAction(tmp.Action, tmp.Type); err != nil {
 		return nil, nil, err
 	}
-	if result, err = parseActionResult(tmp.Result, tmp.Error, tmp.Type); err != nil {
+	if result, err = parseActionResult(tmp.Result, tmp.Type); err != nil {
 		return nil, nil, err
 	}
 
@@ -282,7 +282,7 @@ func parseAction(actionInMap map[string]interface{}, actionType TraceType) (inte
 //	action type TRACE_CREATE => CreateResult
 //	action type TRACE_SUICIDE => uint8(0)
 //	action type TRACE_REWARD => uint8(0)
-func parseActionResult(actionResInMap map[string]interface{}, actionError string, actionType TraceType) (interface{}, error) {
+func parseActionResult(actionResInMap map[string]interface{}, actionType TraceType) (interface{}, error) {
 	actionResJson, err := json.Marshal(actionResInMap)
 	if err != nil {
 		return nil, err

--- a/types/transaction_args.go
+++ b/types/transaction_args.go
@@ -295,7 +295,7 @@ func (args *TransactionArgs) PopulateAndToTransaction(reader ReaderForPopulate) 
 	return args.ToTransaction()
 }
 
-func ConvertTransactionToArgs(from common.Address, tx Transaction) *TransactionArgs {
+func ConvertTransactionToArgs(from common.Address, tx *Transaction) *TransactionArgs {
 	args := &TransactionArgs{}
 
 	txType := tx.Type()

--- a/types/transaction_args_test.go
+++ b/types/transaction_args_test.go
@@ -94,7 +94,7 @@ func TestPopulateNon1559SetCodeAndDynamic(t *testing.T) {
 func TestConvertDynamicFeeTxToArgs(t *testing.T) {
 	dtx := &ethrpctypes.DynamicFeeTx{}
 
-	actual := ConvertTransactionToArgs(common.Address{}, *ethrpctypes.NewTx(dtx))
+	actual := ConvertTransactionToArgs(common.Address{}, ethrpctypes.NewTx(dtx))
 	expect := `{"from":"0x0000000000000000000000000000000000000000","to":null,"gas":null,"value":"0x0","nonce":null,"data":"0x","accessList":[],"type":2}`
 
 	argsJ, _ := json.Marshal(actual)
@@ -104,7 +104,7 @@ func TestConvertDynamicFeeTxToArgs(t *testing.T) {
 func TestConvertLegacyTxToArgs(t *testing.T) {
 	dtx := &ethrpctypes.LegacyTx{}
 
-	actual := ConvertTransactionToArgs(common.Address{}, *ethrpctypes.NewTx(dtx))
+	actual := ConvertTransactionToArgs(common.Address{}, ethrpctypes.NewTx(dtx))
 	expect := `{"from":"0x0000000000000000000000000000000000000000","to":null,"gas":null,"value":"0x0","nonce":null,"data":"0x","type":0}`
 
 	argsJ, _ := json.Marshal(actual)
@@ -114,7 +114,7 @@ func TestConvertLegacyTxToArgs(t *testing.T) {
 func TestConvertAccesslistTxToArgs(t *testing.T) {
 	dtx := &ethrpctypes.AccessListTx{}
 
-	actual := ConvertTransactionToArgs(common.Address{}, *ethrpctypes.NewTx(dtx))
+	actual := ConvertTransactionToArgs(common.Address{}, ethrpctypes.NewTx(dtx))
 	expect := `{"from":"0x0000000000000000000000000000000000000000","to":null,"gas":null,"value":"0x0","nonce":null,"data":"0x","accessList":[],"type":1}`
 
 	argsJ, _ := json.Marshal(actual)
@@ -125,7 +125,7 @@ func TestConvertSetCodeTxToArgs(t *testing.T) {
 	t.Run("empty fields", func(t *testing.T) {
 		dtx := &ethrpctypes.SetCodeTx{AccessList: ethrpctypes.AccessList{}, AuthList: []ethrpctypes.SetCodeAuthorization{}}
 
-		actual := ConvertTransactionToArgs(common.Address{}, *ethrpctypes.NewTx(dtx))
+		actual := ConvertTransactionToArgs(common.Address{}, ethrpctypes.NewTx(dtx))
 		expect := `{"from":"0x0000000000000000000000000000000000000000","to":"0x0000000000000000000000000000000000000000","gas":null,"value":"0x0","nonce":null,"data":"0x","accessList":[],"type":4}`
 
 		argsJ, err := json.Marshal(actual)
@@ -159,7 +159,7 @@ func TestConvertSetCodeTxToArgs(t *testing.T) {
 		}
 
 		from := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-		actual := ConvertTransactionToArgs(from, *ethrpctypes.NewTx(dtx))
+		actual := ConvertTransactionToArgs(from, ethrpctypes.NewTx(dtx))
 
 		assert.Equal(t, &from, actual.From)
 		assert.Equal(t, &to, actual.To)


### PR DESCRIPTION
…ssertions.

Use pointer-based transaction flow (SendTransaction / ConvertTransactionToArgs) and avoid copying SignerManager Refactor type switch in providers/provider_sign.go to use switch v := x.(type) form and remove redundant assertions (S1034)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openweb3/web3go/75)
<!-- Reviewable:end -->
